### PR TITLE
Correct indentation for the health config

### DIFF
--- a/docs/application/health-checks.md
+++ b/docs/application/health-checks.md
@@ -11,11 +11,11 @@ If the Process [exposes a port](/application/port) is it considered healthy afte
 ```yaml
 services:
   web:
-  health:
-    grace: 5
-    interval: 5
-    path: /health
-    timeout: 3
+    health:
+      grace: 5
+      interval: 5
+      path: /health
+      timeout: 3
 ```
 
 #### Options


### PR DESCRIPTION
The `health` in the example is not correctly indented. It should be a property under the service name, not a sibling.