### PR TITLE
Specify CONVOX_HOST as a necessary env var

### DIFF
--- a/docs/console/deploy-keys.md
+++ b/docs/console/deploy-keys.md
@@ -15,5 +15,5 @@ Go to the **Deploy Keys** section, give your deploy key a name, and click on **C
 In your CI environment, download the latest version of the [Convox CLI](/introduction/installation) and use the deploy key like this:
 
 ```
-$ env CONVOX_PASSWORD=<key> convox deploy
+$ env CONVOX_HOST=console.convox.com CONVOX_PASSWORD=<key> convox deploy
 ```


### PR DESCRIPTION
Not sure if this is the intended behavior, but explicitly setting CONVOX_HOST is required to successfully use a deploy key--otherwise, the CLI will prompt for login: https://github.com/convox/rack/blob/master/pkg/cli/helpers.go#L84