### PR TITLE
Fix command to roll back to a previous release

### DIFF
--- a/docs/deployment/rolling-back.md
+++ b/docs/deployment/rolling-back.md
@@ -23,8 +23,9 @@ RTAITJQWMGG  1 month ago  BVZFLIJCRTV
 RPNUPSAXEFG  1 month ago  BRTFWFZLPFZ
 RACMHKRWPXU  1 month ago  BLFRJGIKRQM
 
-$ convox releases promote RHKOIXXVDMJ
-Promoting RHKOIXXVDMJ... UPDATING
+$ convox releases rollback --id RHKOIXXVDMJ
+Rolling back to RHKOIXXVDMJ... OK, RAXHPJHSWZO
+Promoting RAXHPJHSWZO...
 ```
 
 ## Rack


### PR DESCRIPTION
When using the current command I see:

```
~ $ convox releases promote RVTOMLRVKSH -a teespring -w
Promoting RVTOMLRVKSH... ERROR: can not promote an older release, try rollback
```