### PR TITLE
Document AutoscaleExtra

### DIFF
--- a/docs/reference/rack-parameters.md
+++ b/docs/reference/rack-parameters.md
@@ -41,6 +41,12 @@ Autoscale rack instances. See our [Scaling doc](/docs/scaling#autoscale) for mor
 | Default value  | `Yes`       |
 | Allowed values | `Yes`, `No` |
 
+### AutoscaleExtra
+
+The number of instances of extra capacity that autoscale should keep running.
+
+| Default value  | `1` |
+
 ### AvailabilityZones
 
 Override the default availability zones used in a Rack. Please note that updating this parameter once a Rack is installed will require choosing new values for the various SubnetCIDR parameters since two subnets can not exist with the same CIDR simultaneously.


### PR DESCRIPTION
This adds missing documentation of the `AutoscaleExtra` rack param.