### PR TITLE
Remove incorrect information

### DIFF
--- a/docs/deployment/private-registries.md
+++ b/docs/deployment/private-registries.md
@@ -31,7 +31,7 @@ Continuing with our Docker Hub example, the command would be:
     $ convox registries add index.docker.io/v1/ username password
     Adding registry... OK
 
-You will be prompted for your username and password. Once the registry has been added, you can pull private images:
+Once the registry has been added, you can pull private images:
 
     $ convox deploy
     Deploying test


### PR DESCRIPTION
The documentation says that the user will be prompted for username/password; this is incorrect, they must include it in the call to `convox registries add`.

```
$ convox registries add index.docker.io/v1/
ERROR: 3 args required
```