### PR TITLE
docs: troubleshooting rack delete error

### DIFF
--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -26,6 +26,8 @@ As ALB routing rules must have a unique priority, Convox will generate a random 
 
 When deleting a Rack from the Convox Console under certain circumstances the rack is removed from the Console, but the AWS resources are still in AWS. To remove resources you need to go to your AWS account console, then head over to CloudFormation in the same region you rack was created. Under stack there will be stacks with: `rack-name`, `rack-name-app-name`, `rack-name-console-xxx`. Select them and then click Delete from the CloudFormation options. This will remove all the resources created for you rack.
 
+Note: Some resouces as Cloudwatch logs might still exists after this process.
+
 ## My app deployed but I cannot access it
 
 Run `convox services` to find the load balancer endpoints for your application.

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -26,7 +26,7 @@ As ALB routing rules must have a unique priority, Convox will generate a random 
 
 When deleting a Rack from the Convox Console under certain circumstances the rack is removed from the Console, but the AWS resources are still in AWS. To remove resources you need to go to your AWS account console, then head over to CloudFormation in the same region your rack was created. Under stack there will be stacks with: `rack-name`, `rack-name-app-name`, `rack-name-console-xxx`. Select them and then click Delete from the CloudFormation options. This will remove all the resources created for your rack.
 
-Note: Some resources as Cloudwatch logs might still exists after this process.
+Note: Some resources as Cloudwatch logs might still exist after this process.
 
 ## My app deployed but I cannot access it
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -20,6 +20,12 @@ When you know there is an issue and want to stop a deployment, you can run the `
 
 As ALB routing rules must have a unique priority, Convox will generate a random one for each service in the range 1-50000 (the range allowed by AWS).  This is generated from a checksum of the app name, service name, domain name, and a couple of other tweaks.  It is very unlikely, but it is possible to have a collision between two separate services on the same rack.  To solve this, simply slightly amend your app or service name to generate a different checksum.
 
+## I get an error when deleting rack from Convox Console 
+
+### I get `ERROR: ValidationError: Stack with id rack-name does not exist`
+
+When deleting a Rack from the Convox Console under certain circumstances the rack is removed from the Console, but the AWS resources are still in AWS. To remove resources you need to go to your AWS account console, then head over to CloudFormation in the same region you rack was created. Under stack there will be stacks with: `rack-name`, `rack-name-app-name`, `rack-name-console-xxx`. Select them and then click Delete from the CloudFormation options. This will remove all the resources created for you rack.
+
 ## My app deployed but I cannot access it
 
 Run `convox services` to find the load balancer endpoints for your application.

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -24,9 +24,9 @@ As ALB routing rules must have a unique priority, Convox will generate a random 
 
 ### I get `ERROR: ValidationError: Stack with id rack-name does not exist`
 
-When deleting a Rack from the Convox Console under certain circumstances the rack is removed from the Console, but the AWS resources are still in AWS. To remove resources you need to go to your AWS account console, then head over to CloudFormation in the same region you rack was created. Under stack there will be stacks with: `rack-name`, `rack-name-app-name`, `rack-name-console-xxx`. Select them and then click Delete from the CloudFormation options. This will remove all the resources created for you rack.
+When deleting a Rack from the Convox Console under certain circumstances the rack is removed from the Console, but the AWS resources are still in AWS. To remove resources you need to go to your AWS account console, then head over to CloudFormation in the same region your rack was created. Under stack there will be stacks with: `rack-name`, `rack-name-app-name`, `rack-name-console-xxx`. Select them and then click Delete from the CloudFormation options. This will remove all the resources created for your rack.
 
-Note: Some resouces as Cloudwatch logs might still exists after this process.
+Note: Some resources as Cloudwatch logs might still exists after this process.
 
 ## My app deployed but I cannot access it
 


### PR DESCRIPTION
Document case when deleting rack from console and the rack does not show anymore in the console, but resources are still in the AWS account.