### PR TITLE
Existingvpc doc fix

### DIFF
--- a/docs/application/environment.md
+++ b/docs/application/environment.md
@@ -77,6 +77,16 @@ Release: RRJQTMVKRS
 
 `convox env edit` allows you to interactively update your environment variables in a terminal editor 😊
 
+You can use `convox env edit` along with `convox releases` to restore an Environment Variable set from another release:
+
+First run `convox releases -a <app-name>` to identify the correct `RELEASE-ID`
+
+Next, examine the release's environment variables with `convox releases info <RELEASE-ID> -a <app-name>`
+
+Copy the desired variables.
+
+Finally run `convox env edit` paste and save the variables to create and promote a new `RELEASE` for your app with updated environment variables.
+
 ## Promoting your environment variable changes
 
 If you update your env vars through the CLI, that will create a new release containing your changes.  By default this will not be promoted.

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -17,14 +17,14 @@ You can install it via the command line:
 
 ### x86_64 / amd64
 
-    $ curl -L https://convox.s3.amazonaws.com/cli/darwin/convox -o /tmp/convox
+    $ curl -L http://download.convox.com/cli/darwin/convox -o /tmp/convox
     $ sudo mv /tmp/convox /usr/local/bin/convox
     $ sudo chmod 755 /usr/local/bin/convox
 
 ### arm64
 
 ```html
-    $ curl -L https://convox.s3.amazonaws.com/cli/darwin/convox-arm64 -o /tmp/convox
+    $ curl -L http://download.convox.com/cli/darwin/convox-arm64 -o /tmp/convox
     $ sudo mv /tmp/convox /usr/local/bin/convox
     $ sudo chmod 755 /usr/local/bin/convox
 ```
@@ -35,7 +35,7 @@ You can install it via the command line:
 ### x86_64 / amd64
 
 ```html
-    $ curl -L https://convox.s3.amazonaws.com/cli/linux/convox -o /tmp/convox
+    $ curl -L http://download.convox.com/cli/linux/convox -o /tmp/convox
     $ sudo mv /tmp/convox /usr/local/bin/convox
     $ sudo chmod 755 /usr/local/bin/convox
 ```
@@ -43,14 +43,14 @@ You can install it via the command line:
 ### arm64
 
 ```html
-    $ curl -L https://convox.s3.amazonaws.com/cli/linux/convox-arm64 -o /tmp/convox
+    $ curl -L http://download.convox.com/cli/linux/convox-arm64 -o /tmp/convox
     $ sudo mv /tmp/convox /usr/local/bin/convox
     $ sudo chmod 755 /usr/local/bin/convox
 ```
 
 ## Windows
 
-    $ curl -L https://convox.s3.amazonaws.com/cli/windows/convox.exe -O
+    $ curl -L http://download.convox.com/cli/windows/convox.exe -O
 
 # Next steps
 

--- a/docs/reference/rack-parameters.md
+++ b/docs/reference/rack-parameters.md
@@ -122,7 +122,7 @@ Encrypt secrets with KMS.
 
 ### ExistingVpc
 
-Existing VPC ID (if blank, a VPC will be created).
+Existing VPC ID (if blank, a VPC will be created). Paramater [InternetGateway](/reference/rack-parameters#internetgateway) must be set to use [ExistingVPC](/reference/rack-parameters#existingvpc).
 
 
 ### HighAvailability


### PR DESCRIPTION
Param: ExistingVpc had no mention or link of required param: InternetGateway
-added description and link to ExistingVpc param info

- InternetGateway altready mentions and links to ExistingVPC



CLI download links and ENV recovery still do not seem to be live even though I have merged etc.