### PR TITLE
Updated agent syntax and clarified DD example

### DIFF
--- a/docs/application/services.md
+++ b/docs/application/services.md
@@ -49,6 +49,7 @@ or if your agent needs to open host-level ports then use this format:
 services:
   datadog:
     agent:
+      enabled: true
       ports:
         - 8125/udp
         - 8126/tcp

--- a/docs/external-services/datadog.md
+++ b/docs/external-services/datadog.md
@@ -14,23 +14,24 @@ You can deploy the datadog agent as a Convox app with a very simple `convox.yml`
 
 ```
 services:
-  agent:
+  datadog-agent:
     agent:
+      enabled: true
       ports:
         - 8125/udp
         - 8126/tcp
-    image: datadog/agent:latest
-    environment:
-      - DD_API_KEY
-      - DD_APM_ENABLED=true
-    privileged: true
-    scale:
-      cpu: 128
-      memory: 128
-    volumes:
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup/
-      - /proc/:/host/proc/
-      - /var/run/docker.sock:/var/run/docker.sock
+      image: datadog/agent:latest
+      environment:
+        - DD_API_KEY
+        - DD_APM_ENABLED=true
+      privileged: true
+      scale:
+        cpu: 128
+        memory: 128
+      volumes:
+        - /sys/fs/cgroup/:/host/sys/fs/cgroup/
+        - /proc/:/host/proc/
+        - /var/run/docker.sock:/var/run/docker.sock
 ```
 
 ### Application Metrics


### PR DESCRIPTION
Updated to add `enabled: true` under certain agent configurations to ensure: `"SchedulingStrategy": "DAEMON"` is set.  

Fixed indent on data-dog agent example, added enable: true, and clarified the structure.