### PR TITLE
Documentation about resource version and AutoMinorVersionUpgrade

### DIFF
--- a/docs/application/resources.md
+++ b/docs/application/resources.md
@@ -141,3 +141,7 @@ MYDB_NAME=databaseName
 | `encrypted` | `false`          | Encrypt data at rest |
 | `nodes`     | `1`              | Number of nodes      |
 | `version`   | `2.8.24`         | Redis version        |
+
+## AutoMinorVersionUpgrade
+
+In case you specify the minor version on your resource definition you have to turn off the [AutoMinorVersionUpgrade](../reference/app-parameters#autominorversionupgrade) on your app parameter. It's enabled by default and it will update the DB instance during the maintenance window.


### PR DESCRIPTION
The default value is `true`, even when the minor version is specified, it must be turned off when the minor version is specified on the resource definition.